### PR TITLE
支持 Prometheus metrics 的内容输出格式。

### DIFF
--- a/http_rest.go
+++ b/http_rest.go
@@ -86,6 +86,15 @@ func (rest *HttpRestProvider) register(web HttpURL, handlerList []HandlerFunc) {
 			response = results
 		}
 		v, _ = json.Marshal(response)
+		// it works when importing promehttp handler for /metrics.
+		if web.Uri == "/metrics" {
+			str := string(v)
+			str = strings.ReplaceAll(str, "\\\"", "\"")
+			str = strings.ReplaceAll(str, "\\n", "\r\n")
+			str = strings.ReplaceAll(str, "\"", "")
+			fmt.Fprint(w, str)
+			return
+		}
 		w.Write(v)
 	})
 }


### PR DESCRIPTION
我发现阿里巴巴的开源项目mongoshake 引用了这个依赖库，在想对 mongoshake 引入 Prometheus 依赖时，发现无法将响应体内容直接按 Prometheus metrics 的要求格式输出。